### PR TITLE
Add conditional loading of `vfio_virqfd` kernel module

### DIFF
--- a/modules/vfio/default.nix
+++ b/modules/vfio/default.nix
@@ -54,7 +54,8 @@ in {
       ]);
 
     boot.initrd.kernelModules =
-      [ "vfio_virqfd" "vfio_pci" "vfio_iommu_type1" "vfio" ];
+      [ "vfio_pci" "vfio_iommu_type1" "vfio" ] ++ (if lib.versionOlder pkgs.linux.version "6.2" then [ "vfio_virqfd" ] else []);
+      
     boot.blacklistedKernelModules =
       optionals cfg.blacklistNvidia [ "nvidia" "nouveau" ];
   };

--- a/modules/vfio/default.nix
+++ b/modules/vfio/default.nix
@@ -54,7 +54,7 @@ in {
       ]);
 
     boot.initrd.kernelModules =
-      [ "vfio_pci" "vfio_iommu_type1" "vfio" ] ++ (if lib.versionOlder pkgs.linux.version "6.2" then [ "vfio_virqfd" ] else []);
+      [ "vfio_pci" "vfio_iommu_type1" "vfio" ] ++ lib.optionals lib.versionOlder pkgs.linux.version "6.2" [ "vfio_virqfd" ];
       
     boot.blacklistedKernelModules =
       optionals cfg.blacklistNvidia [ "nvidia" "nouveau" ];


### PR DESCRIPTION
Since Linux kernel version 6.2 `vfio_virqfd` was merged into `vfio` kernel module [1]. This PR loads the `vfio_virqfd` kernel module only if the kernel version is older than 6.2. This enables the usage of the `vfio` module of this flake with kernel versions >= 6.2.

Please let me know if there is a better way to create a conditional entry in a list.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e2d55709398e62cf53e5c7df3758ae52cc62d63a