### PR TITLE
Add WantedBy to libvirtd configuration service

### DIFF
--- a/modules/libvirtd/domain.nix
+++ b/modules/libvirtd/domain.nix
@@ -874,6 +874,7 @@ in {
   };
 
   config = mkIf cfg.declarative {
+    systemd.services.libvirtd-config.wantedBy = [ "multi-user.target" ];
     systemd.services.libvirtd-config.script = lib.mkAfter ''
       mkdir -p /var/lib/libvirt/qemu
       mkdir -p /var/lib/libvirt/qemu/autostart

--- a/modules/libvirtd/network.nix
+++ b/modules/libvirtd/network.nix
@@ -254,6 +254,7 @@ in {
   };
 
   config = mkIf cfg.declarative {
+    systemd.services.libvirtd-config.wantedBy = [ "multi-user.target" ];
     systemd.services.libvirtd-config.script = lib.mkAfter ''
       mkdir -p /var/lib/libvirt/qemu/networks
       mkdir -p /var/lib/libvirt/qemu/networks/autostart


### PR DESCRIPTION
The libvirtd configuration service `libvirtd-config.service` is currently not being restarted after a configuration change. It starts at system start, but not after changing e.g. domains and activating the new configuration. By adding WantedBy to the corresponding systemd service unit the service starts now.