### PR TITLE
Add option to add additional custom xml into `<devices>` section

### DIFF
--- a/modules/libvirtd/domain.nix
+++ b/modules/libvirtd/domain.nix
@@ -874,6 +874,7 @@ in {
   };
 
   config = mkIf cfg.declarative {
+    systemd.services.libvirtd-config.wantedBy = [ "multi-user.target" ];
     systemd.services.libvirtd-config.script = lib.mkAfter ''
       mkdir -p /var/lib/libvirt/qemu
       mkdir -p /var/lib/libvirt/qemu/autostart

--- a/modules/libvirtd/domain.nix
+++ b/modules/libvirtd/domain.nix
@@ -531,7 +531,8 @@ let
               };
 
               devicesExtraXml = mkOption {
-                type = types.str;
+                type = types.lines;
+                default = "";
                 description = mdDoc ''
                   Extra raw XML that is added to <devices> section
                 '';

--- a/modules/libvirtd/domain.nix
+++ b/modules/libvirtd/domain.nix
@@ -530,6 +530,13 @@ let
                 '';
               };
 
+              devicesExtraXml = mkOption {
+                type = types.str;
+                description = mdDoc ''
+                  Extra raw XML that is added to <devices> section
+                '';
+              };
+
               kvmfr = mkOption {
                 type = types.nullOr kvmfrOptionsType;
                 description = mdDoc ''
@@ -825,6 +832,8 @@ let
             </channel>
           ''
         }
+
+        ${definition.devicesExtraXml}
       </devices>
 
       ${optionalString (definition.kvmfr != null) mkKvmfrXml definition.kvmfr}

--- a/modules/libvirtd/network.nix
+++ b/modules/libvirtd/network.nix
@@ -254,6 +254,7 @@ in {
   };
 
   config = mkIf cfg.declarative {
+    systemd.services.libvirtd-config.wantedBy = [ "multi-user.target" ];
     systemd.services.libvirtd-config.script = lib.mkAfter ''
       mkdir -p /var/lib/libvirt/qemu/networks
       mkdir -p /var/lib/libvirt/qemu/networks/autostart


### PR DESCRIPTION
The current domain configuration generation mechanism is not able to generate all possible device types. To (temporarily) overcome this limitation, this PR adds an option to pass custom raw XML to the `<devices>` section of the generated domain configuration. 

The changes should probably be reverted after #60 was implemented.